### PR TITLE
Fractional Costed Cards Fix

### DIFF
--- a/Sources/Swiftfall/Swiftfall.swift
+++ b/Sources/Swiftfall/Swiftfall.swift
@@ -235,7 +235,7 @@ public class Swiftfall {
         public let layout: String?
         
         // The card’s converted mana cost. Note that some funny cards have fractional mana costs.
-        public let cmc: String?
+        public let cmc: Double?
 
         // The type line of this card.
         public let type_line: String?

--- a/Sources/Swiftfall/Swiftfall.swift
+++ b/Sources/Swiftfall/Swiftfall.swift
@@ -235,7 +235,7 @@ public class Swiftfall {
         public let layout: String?
         
         // The card’s converted mana cost. Note that some funny cards have fractional mana costs.
-        public let cmc: Int?
+        public let cmc: String?
 
         // The type line of this card.
         public let type_line: String?


### PR DESCRIPTION
Cards like Little Girl which have a fractional mana cost did not work. Now mana_cost is a double now. 