### PR TITLE
Warning for ScryfallErrors

### DIFF
--- a/Sources/Swiftfall/Swiftfall.swift
+++ b/Sources/Swiftfall/Swiftfall.swift
@@ -106,12 +106,20 @@ public class Swiftfall {
     struct ScryfallError: Codable, Error, CustomStringConvertible {
         
         let code: String
-        let type: String
+        let type: String?
         let status: Int
+        let warnings: [String]?
+        
         let details: String
         
         public var description: String {
-            return "Error: \(code)\nDetails: \(details)\n"
+            var text = "Error: \(code)\nDetails: \(details)\n"
+            if let warns = warnings {
+                for warning in warns {
+                    text += warning + "\n"
+                }
+            }
+            return text
         }
     }
     

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -298,6 +298,14 @@ class Tests: XCTestCase {
         }
     }
     
+    func testErrorWarning() throws {
+        do {
+            _ = try Swiftfall.getCatalog(catalog: "types")
+        } catch {
+            print(error)
+        }
+    }
+    
     
     
     func testPerformanceExample() throws {


### PR DESCRIPTION
Now, if Scryfall gives us a warning about an error, we can handle that. Additionally, now the Error will print the warning. 