### PR TITLE
Remove missing properties

### DIFF
--- a/Sources/Swiftfall/Swiftfall.swift
+++ b/Sources/Swiftfall/Swiftfall.swift
@@ -403,9 +403,6 @@ public class Swiftfall {
         // This card’s watermark, if any.
         public let watermark: String?
         
-        // True if card is from the future
-        public let futureshifted: Bool
-        
         // This card’s border color: black, borderless, gold, silver, or white.
         public let border_color: String
         

--- a/Sources/Swiftfall/Swiftfall.swift
+++ b/Sources/Swiftfall/Swiftfall.swift
@@ -403,9 +403,6 @@ public class Swiftfall {
         // This card’s watermark, if any.
         public let watermark: String?
         
-        // True if this card is timeshifted.
-        public let timeshifted: Bool
-        
         // True if this card is colorshifted.
         public let colorshifted: Bool
         

--- a/Sources/Swiftfall/Swiftfall.swift
+++ b/Sources/Swiftfall/Swiftfall.swift
@@ -403,9 +403,6 @@ public class Swiftfall {
         // This card’s watermark, if any.
         public let watermark: String?
         
-        // True if this card is colorshifted.
-        public let colorshifted: Bool
-        
         // True if card is from the future
         public let futureshifted: Bool
         


### PR DESCRIPTION
These three properties have been removed from Face in the Scryfall API. Right now Swiftfall crashes when you try to fetch cards since they are missing.