### PR TITLE
Fixed purchaseUris by making it optional.

### DIFF
--- a/Sources/Swiftfall/Swiftfall.swift
+++ b/Sources/Swiftfall/Swiftfall.swift
@@ -446,7 +446,7 @@ public class Swiftfall {
         public let colors: [String]?
         
         // Online listings for these cards names.
-        public let purchaseUris: [String:String]
+        public let purchaseUris: [String:String]?
         
         // Flavor text on the card, if there is any
         public let flavorText: String?


### PR DESCRIPTION
There are a number of sets that contain cards with missing keys. This causes a decoding error when trying to call set.getCards() which returns an empty array. This PR fixes the issue by making purchaseUris optional.

`▿ Result<CardList>
  ▿ failure : DecodingError
    ▿ keyNotFound : 2 elements
      - .0 : CodingKeys(stringValue: "purchaseUris", intValue: nil)
      ▿ .1 : Context
        ▿ codingPath : 2 elements
          - 0 : CodingKeys(stringValue: "data", intValue: nil)
          ▿ 1 : _JSONKey(stringValue: "Index 15", intValue: 15)
            - stringValue : "Index 15"
            ▿ intValue : Optional<Int>
              - some : 15
        - debugDescription : "No value associated with key CodingKeys(stringValue: \"purchaseUris\", intValue: nil) (\"purchaseUris\"), converted to purchase_uris."
        - underlyingError : nil
 `

Affected sets are:
ddf, me3, me1, psus, 6ed, 5ed, ren, 4bb, 4ed, sum, leg, 3ed, fbb, arn, cei, ced, 2ed, leb,lea